### PR TITLE
統合テスト及びCIの追加

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,14 @@
+name: Integration tests
+
+on: [push, pull_request]
+
+jobs:
+  build-and-integration-test:
+    name: Test integration-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run integration tests
+        shell: bash
+        run: ./tests/run_integration_tests.sh

--- a/.github/workflows/super_lint.yml
+++ b/.github/workflows/super_lint.yml
@@ -1,0 +1,24 @@
+name: Super linter
+
+on: [push, pull_request]
+
+jobs:
+  lint-code-base:
+    name: Apply cargo fmt and cargo clippy
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,14 @@
+name: Unit tests
+
+on: [push, pull_request]
+
+jobs:
+  build-and-unit-test:
+    name: Test unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run unit tests
+        shell: bash
+        run: ./tests/run_unit_tests.sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::str::FromStr;
 
 use mrbgpdv2::config::Config;
@@ -5,7 +6,15 @@ use mrbgpdv2::peer::Peer;
 
 #[tokio::main]
 async fn main() {
-    let configs = vec![Config::from_str("64512 127.0.0.1 65413 127.0.0.2 active").unwrap()];
+    let config =
+        env::args()
+            .skip(1)
+            .fold("".to_owned(), |mut acc, s| {
+                acc += &(s.to_owned() + " ");
+                acc
+            });
+    let config = config.trim_end();
+    let configs = vec![Config::from_str(&config).unwrap()];
     let mut peers: Vec<Peer> = configs.into_iter().map(Peer::new).collect();
     for peer in &mut peers {
         peer.start();

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -60,8 +60,8 @@ mod tests {
     #[tokio::test]
     async fn loclib_can_lookup_routing_table() {
         // 本テストの値は環境によって異なる。
-        // 本実装では開発機, テスト実施機に192.168.1.0/24に属するIPが付与されていることを仮定している。
-        let network = Ipv4Network::new("192.168.1.0".parse().unwrap(), 24).unwrap();
+        // 本実装では開発機, テスト実施機に10.200.100.0/24に属するIPが付与されていることを仮定している。
+        let network = Ipv4Network::new("10.200.100.0".parse().unwrap(), 24).unwrap();
         let routes = LocRib::lookup_kernel_routing_table(network).await.unwrap();
         let expected = vec![(network, NextHop::DirectConnected)];
         assert_eq!(routes, expected);

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  host1:
+    cap_add:
+      - NET_ADMIN # NET_ADMINがないと、ルーティングテーブルの操作ができない。
+    build: # Build Contextを変更して、Dockerfile, docker-compose.ymlより上位にあるファイルをCOPYできるようにしている。
+      context: ../
+      dockerfile: ./tests/host1/Dockerfile
+    networks:
+      bgp-test-network:
+        ipv4_address: 10.200.100.2
+      host1-network:
+        ipv4_address: 10.100.210.2
+    depends_on:
+      - host2 # host2から起動するようにしているのは、現状の実装ではBGPのpassiveモード側から起動しないとネイバーがはれないため。
+  host2:
+    cap_add:
+      - NET_ADMIN # NET_ADMINがないと、ルーティングテーブルの操作ができない。
+    build: # Build Contextを変更して、Dockerfile, docker-compose.ymlより上位にあるファイルをCOPYできるようにしている。
+      context: ../
+      dockerfile: ./tests/host2/Dockerfile
+    networks:
+      bgp-test-network:
+        ipv4_address: 10.200.100.3
+      host2-network:
+        ipv4_address: 10.100.220.3
+
+networks:
+  bgp-test-network: # host1, host2がピアリングするためのネットワーク
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.200.100.0/24
+  host1-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.100.210.0/24
+  host2-network: # host2 -> host1にアドバタイズするネットワーク
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.100.220.0/24

--- a/tests/host1/Dockerfile
+++ b/tests/host1/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust
+
+WORKDIR /mrbgpdv2
+COPY . .
+RUN rustup default nightly
+RUN cargo build
+RUN apt-get update
+RUN apt-get -y install iputils-ping
+CMD ./target/debug/mrbgpdv2 "64512 10.200.100.2 64513 10.200.100.3 active"

--- a/tests/host2/Dockerfile
+++ b/tests/host2/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust
+
+WORKDIR /mrbgpdv2
+COPY . .
+RUN rustup default nightly
+RUN cargo build
+RUN apt-get update
+RUN apt-get -y install iputils-ping
+CMD ./target/debug/mrbgpdv2 "64513 10.200.100.3 64512 10.200.100.2 passive"

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+docker-compose -f ./tests/docker-compose.yml build --no-cache
+docker-compose -f ./tests/docker-compose.yml up -d
+HOST_2_LOOPBACK_IP=10.100.220.3
+docker-compose -f ./tests/docker-compose.yml exec -T host1 ping -c 5 $HOST_2_LOOPBACK_IP
+
+# docker-compose execの終了コードは実行したコマンド、
+# ここでは`ping -c 5 $HOST_2_LOOPBACK_IP`のものである。
+# そのため、BGPでルートを交換し、pingが通れば0, それ以外の場合は1である。
+TEST_RESULT=$?
+if [ $TEST_RESULT -eq 0 ]; then
+    printf "\e[32m%s\e[m\n" "統合テストが成功しました。"
+else
+    printf "\e[31m%s\e[m\n" "統合テストが失敗しました。"
+fi
+
+exit $TEST_RESULT

--- a/tests/run_unit_tests.sh
+++ b/tests/run_unit_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker-compose -f ./tests/docker-compose.yml build --no-cache
+docker-compose -f ./tests/docker-compose.yml up -d
+docker-compose -f ./tests/docker-compose.yml exec -T host2 cargo test -- --test-threads=1 --nocapture


### PR DESCRIPTION
# 説明すること
とくにない
Intergrationテストは現段階ではpassされない。

# run integration log
```
mrcsce@pop-os:~/programming/rustProjects/bgp/mrbgpdv2$ sudo ./tests/run_integration_tests.sh 
<中略>
PING 10.100.220.3 (10.100.220.3) 56(84) bytes of data.

--- 10.100.220.3 ping statistics ---
5 packets transmitted, 0 received, 100% packet loss, time 4084ms

統合テストが失敗しました。
```
# run unit test log
```
   Compiling mrbgpdv2 v0.1.0 (/mrbgpdv2)
    Finished test [unoptimized + debuginfo] target(s) in 2.87s
     Running unittests (target/debug/deps/mrbgpdv2-306f9e98ae951eec)

running 7 tests
test packets::header::tests::convert_bytes_to_header_and_header_to_bytes ... ok
test packets::open::tests::convert_bytes_to_open_message_and_open_message_to_bytes ... ok
test peer::tests::peer_can_transition_to_connect_state ... ok
test peer::tests::peer_can_transition_to_established_state ... ok
test peer::tests::peer_can_transition_to_open_confirm_state ... ok
test peer::tests::peer_can_transition_to_open_sent_state ... ok
test routing::tests::loclib_can_lookup_routing_table ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.82s

     Running unittests (target/debug/deps/mrbgpdv2-4604093a4ebff180)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests mrbgpdv2

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

mrcsce@pop-os:~/programming/rustProjects/bgp/mrbgpdv2$ 
```