### PR TITLE
Update messageを受信可能にする

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,3 +27,10 @@ pub struct CreateConnectionError {
     #[from]
     source: anyhow::Error,
 }
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct ConstructIpv4NetworkError {
+    #[from]
+    source: anyhow::Error,
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -12,7 +12,8 @@ pub enum Event {
     KeepAliveMsg(KeepaliveMessage), // MsgはMessageの省略形。BGPのRFC内での定義に従っている。
     UpdateMsg(UpdateMessage),       // BGPのRFC内での定義に従っている。
     Established, // StateがEstablishedに遷移したことを表す。存在するほうが実装が楽なので追加した本実装オリジナルのイベント
-    // LocRib / AdjRibOutが変わったときのイベント。存在するほうが実装が楽なので追加した。
+    // LocRib / AdjRibOu / AdjRibIntが変わったときのイベント。存在するほうが実装が楽なので追加した。
     LocRibChanged,
     AdjRibOutChanged,
+    AdjRibInChanged,
 }

--- a/src/packets/update.rs
+++ b/src/packets/update.rs
@@ -102,7 +102,10 @@ impl TryFrom<BytesMut> for UpdateMessage {
         let total_path_attribute_length = u16::from_be_bytes(
             bytes[withdrawn_routes_end_index..path_attributes_start_index]
                 .try_into()
-                .context(format!("Bytes: {:?}からtotal_path_attribute_lengthに変換できませんでした", &bytes))?,
+                .context(format!(
+                    "Bytes: {:?}からtotal_path_attribute_lengthに変換できませんでした",
+                    &bytes
+                ))?,
         );
 
         let path_attributes_bytes = &bytes[path_attributes_start_index

--- a/src/packets/update.rs
+++ b/src/packets/update.rs
@@ -15,11 +15,11 @@ use super::header::MessageType;
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub struct UpdateMessage {
     header: Header,
-    withdrawn_routes: Vec<Ipv4Network>,
+    pub withdrawn_routes: Vec<Ipv4Network>,
     withdrawn_routes_length: u16, // ルート数ではなく、bytesにしたときのオクテット数。
-    path_attributes: Vec<PathAttribute>,
+    pub path_attributes: Vec<PathAttribute>,
     path_attributes_length: u16, // bytesにした時のオクテット数。
-    network_layer_reachability_information: Vec<Ipv4Network>,
+    pub network_layer_reachability_information: Vec<Ipv4Network>,
     // NLRIのオクテット数はBGP UpdateMessageに含めず、
     // Headerのサイズを計算することにしか使用しないため、
     // メンバに含めていない。

--- a/src/path_attribute.rs
+++ b/src/path_attribute.rs
@@ -1,6 +1,7 @@
+use anyhow::Context;
 use bytes::{BufMut, BytesMut};
 
-use crate::bgp_type::AutonomousSystemNumber;
+use crate::{bgp_type::AutonomousSystemNumber, error::ConvertBytesToBgpMessageError};
 use std::{collections::BTreeSet, net::Ipv4Addr};
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -28,6 +29,45 @@ impl PathAttribute {
         } else {
             length + 1 // attribute lengthを表すoctet分追加。
         }
+    }
+
+    pub fn from_u8_slice(
+        bytes: &[u8],
+    ) -> Result<Vec<PathAttribute>, ConvertBytesToBgpMessageError> {
+        let mut path_attributes = vec![];
+        let mut i = 0;
+        while bytes.len() > i {
+            let attribute_flag = bytes[i];
+            let attribute_length_octets = (attribute_flag & 0b00010000) + 1;
+            let attribute_type_code = bytes[i + 1];
+            let attribute_length = if attribute_length_octets == 1 {
+                bytes[i + 2] as usize
+            } else {
+                u16::from_be_bytes(bytes[i + 2..i + 4].try_into().context("aaa")?) as usize
+            };
+
+            let attribute_start_index = i + 1 + attribute_length_octets as usize + 1;
+            let attribute_end_index = attribute_start_index + attribute_length;
+            let path_attribute = match attribute_type_code {
+                1 => PathAttribute::Origin(Origin::try_from(bytes[attribute_start_index])?),
+                2 => PathAttribute::AsPath(AsPath::try_from(
+                    &bytes[attribute_start_index..attribute_end_index],
+                )?),
+                3 => {
+                    let addr = Ipv4Addr::new(
+                        bytes[attribute_start_index],
+                        bytes[attribute_start_index + 1],
+                        bytes[attribute_start_index + 2],
+                        bytes[attribute_start_index + 3],
+                    );
+                    PathAttribute::NextHop(addr)
+                }
+                _ => PathAttribute::DontKnow(bytes[i..attribute_end_index].to_owned()),
+            };
+            path_attributes.push(path_attribute);
+            i = attribute_end_index;
+        }
+        Ok(path_attributes)
     }
 }
 
@@ -108,6 +148,22 @@ pub enum Origin {
     Incomplete,
 }
 
+impl TryFrom<u8> for Origin {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Origin::Igp),
+            1 => Ok(Origin::Egp),
+            2 => Ok(Origin::Incomplete),
+            _ => Err(anyhow::anyhow!(format!(
+                "value: {}をOriginに変換出来ませんでした。",
+                value
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum AsPath {
     AsSequence(Vec<AutonomousSystemNumber>),
@@ -159,6 +215,37 @@ impl AsPath {
         };
         // AsSetかAsSequenceかを表すoctet + asの数を表すoctet + asのbytesの値
         1 + 1 + as_bytes_length
+    }
+}
+
+impl TryFrom<&[u8]> for AsPath {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        match value[0] {
+            1 => {
+                let mut ases = BTreeSet::new();
+                let mut i = 2;
+                while i < value.len() {
+                    ases.insert(u16::from_be_bytes(value[i..i + 2].try_into()?).into());
+                    i += 2;
+                }
+                Ok(AsPath::AsSet(ases))
+            }
+            2 => {
+                let mut ases = vec![];
+                let mut i = 2;
+                while i < value.len() {
+                    ases.push(u16::from_be_bytes(value[i..i + 2].try_into()?).into());
+                    i += 2;
+                }
+                Ok(AsPath::AsSequence(ases))
+            }
+            _ => Err(anyhow::anyhow!(format!(
+                "value: {:?}をAsPathに変換出来ませんでした。",
+                &value
+            ))),
+        }
     }
 }
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -138,7 +138,18 @@ impl Peer {
                     self.adj_rib_in.install_from_update(update, &self.config);
                     self.event_queue.enqueue(Event::AdjRibInChanged);
                 }
-                Event::AdjRibInChanged => {}
+                Event::AdjRibInChanged => {
+                    self.loc_rib
+                        .lock()
+                        .await
+                        .install_from_adj_rib_in(&self.adj_rib_in);
+                    self.loc_rib
+                        .lock()
+                        .await
+                        .write_to_kernel_routing_table()
+                        .await;
+                    self.event_queue.enqueue(Event::LocRibChanged);
+                }
                 _ => {}
             },
         }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -11,7 +11,7 @@ use crate::event_queue::EventQueue;
 use crate::packets::keepalive;
 use crate::packets::message::Message;
 use crate::packets::update::UpdateMessage;
-use crate::routing::{AdjRibOut, LocRib, AdjRibIn};
+use crate::routing::{AdjRibIn, AdjRibOut, LocRib};
 use crate::state::State;
 
 /// [BGPのRFCで示されている実装方針](https://datatracker.ietf.org/doc/html/rfc4271#section-8)では、
@@ -138,8 +138,7 @@ impl Peer {
                     self.adj_rib_in.install_from_update(update, &self.config);
                     self.event_queue.enqueue(Event::AdjRibInChanged);
                 }
-                Event::AdjRibInChanged => {
-                }
+                Event::AdjRibInChanged => {}
                 _ => {}
             },
         }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -11,7 +11,7 @@ use crate::event_queue::EventQueue;
 use crate::packets::keepalive;
 use crate::packets::message::Message;
 use crate::packets::update::UpdateMessage;
-use crate::routing::{AdjRibOut, LocRib};
+use crate::routing::{AdjRibOut, LocRib, AdjRibIn};
 use crate::state::State;
 
 /// [BGPのRFCで示されている実装方針](https://datatracker.ietf.org/doc/html/rfc4271#section-8)では、
@@ -25,6 +25,7 @@ pub struct Peer {
     config: Config,
     loc_rib: Arc<Mutex<LocRib>>,
     adj_rib_out: AdjRibOut,
+    adj_rib_in: AdjRibIn,
 }
 
 impl Peer {
@@ -32,6 +33,7 @@ impl Peer {
         let state = State::Idle;
         let event_queue = EventQueue::new();
         let adj_rib_out = AdjRibOut::new();
+        let adj_rib_in = AdjRibIn::new();
         Self {
             state,
             event_queue,
@@ -39,6 +41,7 @@ impl Peer {
             tcp_connection: None,
             loc_rib,
             adj_rib_out,
+            adj_rib_in,
         }
     }
 
@@ -48,7 +51,7 @@ impl Peer {
 
     pub async fn next(&mut self) {
         if let Some(event) = self.event_queue.dequeue() {
-            self.handle_event(&event).await;
+            self.handle_event(event).await;
         }
 
         if let Some(conn) = &mut self.tcp_connection {
@@ -68,7 +71,7 @@ impl Peer {
         }
     }
 
-    async fn handle_event(&mut self, event: &Event) {
+    async fn handle_event(&mut self, event: Event) {
         match &self.state {
             State::Idle => match event {
                 Event::ManualStart => {
@@ -130,7 +133,12 @@ impl Peer {
                             .send(Message::Update(update))
                             .await;
                     }
-                    println!("UpdateMessage send!!!!")
+                }
+                Event::UpdateMsg(update) => {
+                    self.adj_rib_in.install_from_update(update, &self.config);
+                    self.event_queue.enqueue(Event::AdjRibInChanged);
+                }
+                Event::AdjRibInChanged => {
                 }
                 _ => {}
             },

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use crate::bgp_type::AutonomousSystemNumber;
 use crate::config::Config;
-use crate::error::ConfigParseError;
+use crate::error::{ConfigParseError, ConstructIpv4NetworkError, ConvertBytesToBgpMessageError};
 use crate::path_attribute::{AsPath, Origin, PathAttribute};
 use anyhow::{Context, Result};
 use bytes::{BufMut, BytesMut};
@@ -75,6 +75,62 @@ impl Ipv4Network {
             25..33 => 5,
             _ => panic!("prefixが0..32の間ではありません！"),
         }
+    }
+
+    pub fn new(addr: Ipv4Addr, prefix: u8) -> Result<Self, ConstructIpv4NetworkError> {
+        let net = ipnetwork::Ipv4Network::new(addr, prefix).context(format!(
+            "Ipv4NetworkをConstruct出来ませんでした。addr: {}, prefix: {}",
+            addr, prefix
+        ))?;
+        Ok(Self(net))
+    }
+
+    /// 本来、From Traitを実装するべきだと思うけれど、
+    /// Vec<..>に実装するのが、New Type Patternが必要になり
+    /// 大変なので変な関連関数を追加することで対応した。
+    pub fn from_u8_slice(bytes: &[u8]) -> Result<Vec<Self>, ConvertBytesToBgpMessageError> {
+        let mut networks = vec![];
+        let mut i = 0;
+        while bytes.len() > i {
+            let prefix = bytes[i];
+            i += 1;
+            if prefix == 0 {
+                networks.push(Ipv4Network::new(Ipv4Addr::new(0, 0, 0, 0), prefix).context("")?);
+            } else if 1 <= prefix && prefix <= 8 {
+                networks
+                    .push(Ipv4Network::new(Ipv4Addr::new(bytes[i], 0, 0, 0), prefix).context("")?);
+                i += 1;
+            } else if 9 <= prefix && prefix <= 16 {
+                networks.push(
+                    Ipv4Network::new(Ipv4Addr::new(bytes[i], bytes[i + 1], 0, 0), prefix)
+                        .context("bytes -> Ipv4に変換出来ませんでした。")?,
+                );
+                i += 2;
+            } else if 17 <= prefix && prefix <= 24 {
+                networks.push(
+                    Ipv4Network::new(
+                        Ipv4Addr::new(bytes[i], bytes[i + 1], bytes[i + 2], 0),
+                        prefix,
+                    )
+                    .context("bytes -> Ipv4に変換出来ませんでした。")?,
+                );
+                i += 3;
+            } else if 24 <= prefix && prefix <= 32 {
+                networks.push(
+                    Ipv4Network::new(
+                        Ipv4Addr::new(bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]),
+                        prefix,
+                    )
+                    .context("bytes -> Ipv4に変換出来ませんでした。")?,
+                );
+                i += 4;
+            } else {
+                return Err(ConvertBytesToBgpMessageError::from(anyhow::anyhow!(
+                    "bytes -> Ipv4Networkに変換が出来ませんでした。Prefixが0-32の間ではありません。"
+                )));
+            };
+        }
+        Ok(networks)
     }
 }
 

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -97,17 +97,17 @@ impl Ipv4Network {
             i += 1;
             if prefix == 0 {
                 networks.push(Ipv4Network::new(Ipv4Addr::new(0, 0, 0, 0), prefix).context("")?);
-            } else if 1 <= prefix && prefix <= 8 {
+            } else if (1..=8).contains(&prefix) {
                 networks
                     .push(Ipv4Network::new(Ipv4Addr::new(bytes[i], 0, 0, 0), prefix).context("")?);
                 i += 1;
-            } else if 9 <= prefix && prefix <= 16 {
+            } else if (9..=16).contains(&prefix) {
                 networks.push(
                     Ipv4Network::new(Ipv4Addr::new(bytes[i], bytes[i + 1], 0, 0), prefix)
                         .context("bytes -> Ipv4に変換出来ませんでした。")?,
                 );
                 i += 2;
-            } else if 17 <= prefix && prefix <= 24 {
+            } else if (17..=24).contains(&prefix) {
                 networks.push(
                     Ipv4Network::new(
                         Ipv4Addr::new(bytes[i], bytes[i + 1], bytes[i + 2], 0),
@@ -116,7 +116,7 @@ impl Ipv4Network {
                     .context("bytes -> Ipv4に変換出来ませんでした。")?,
                 );
                 i += 3;
-            } else if 24 <= prefix && prefix <= 32 {
+            } else if (24..=32).contains(&prefix) {
                 networks.push(
                     Ipv4Network::new(
                         Ipv4Addr::new(bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]),


### PR DESCRIPTION
# テスト結果

```
mrcsce@pop-os:~/programming/rustProjects/bgp/mrbgpdv2$ sudo ./tests/run_integration_tests.sh 
<中略>
Successfully built 09fb776025aa
Successfully tagged tests_host1:latest
Recreating tests_host2_1 ... done
Recreating tests_host1_1 ... done
PING 10.100.220.3 (10.100.220.3) 56(84) bytes of data.
64 bytes from 10.100.220.3: icmp_seq=1 ttl=64 time=0.101 ms
64 bytes from 10.100.220.3: icmp_seq=2 ttl=64 time=0.051 ms
64 bytes from 10.100.220.3: icmp_seq=3 ttl=64 time=0.059 ms
64 bytes from 10.100.220.3: icmp_seq=4 ttl=64 time=0.062 ms
64 bytes from 10.100.220.3: icmp_seq=5 ttl=64 time=0.065 ms

--- 10.100.220.3 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 4102ms
rtt min/avg/max/mdev = 0.051/0.067/0.101/0.017 ms
統合テストが成功しました。
mrcsce@pop-os:~/programming/rustProjects/bgp/mrbgpdv2$ git status
```

# 問題
- ただし、新規ルート以外も追加するようになっている。すなわちPeer間で交互にルートを無限交換しあっている。

